### PR TITLE
Switch to NASM syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # calculator-asm
-An CLI calculator program in x86-64 assembly
+An x86-64 Linux assembly CLI calculator program
 
 # Creating an executable
-Run assembler
+Run assembler to create object file
 
-```as calc.asm -o calc.o```
+```nasm -f elf64 calc.asm -o calc.o```
 
-Next run gcc
+Next run linker
 
-```gcc -o calc calc.o -nostdlib -static```
+```ld calc.o -o calc```
 
 Execute with: ```./calc```
+
+## Or use these commands together with an easy one-liner
+```nasm -f elf64 calc.asm -o calc.o && ld calc.o -o calc && ./calc```

--- a/calc.asm
+++ b/calc.asm
@@ -1,5 +1,13 @@
-.global _start
-.intel_syntax noprefix
+section .data
+        first_num_prompt db "Enter the first integer: "
+        second_num_prompt db "Enter the second integer: "
+        operation_prompt db "What operation would you like (+ OR -): "
+
+section .bss
+        input resb 16
+
+section .text
+        .global _start
 
 
 _start:
@@ -51,18 +59,3 @@ _start:
         //lea rsi, [new_line]
         //mov rdx, 1
         //syscall
-        
-        
-        
-
-first_num_prompt:
-    .asciz "Enter the first integer: "
-
-second_num_prompt:
-    .asciz "Enter the second integer: "
-
-operation_prompt:
-    .asciz "What operation would you like (+ OR -): "
-
-new_line:
-    .asciz "\n"

--- a/calc.asm
+++ b/calc.asm
@@ -8,7 +8,7 @@ section .bss
         second_num_input resb 16
 
 section .text
-        .global _start
+        global _start
 
 
 _start:

--- a/calc.asm
+++ b/calc.asm
@@ -16,14 +16,7 @@ _start:
 
         call _second_num_prompt
         
-        // sys read
-        mov rax, 0
-        sub rsp, 8
-        mov rdi, 0
-        lea rsi, [rsp]
-        // TODO: store users input from rsp
-        mov rdx, 1
-        syscall
+        call _get_first_num
 
         // sys write
         mov rax, 1
@@ -56,6 +49,14 @@ _start:
         //lea rsi, [new_line]
         //mov rdx, 1
         //syscall
+
+_get_first_num:
+        mov rax, 0
+        mov rdi, 0
+        mov rsi, input
+        mov rdx, 16
+        syscall
+        ret
 
 _first_num_prompt:
         mov rax, 1

--- a/calc.asm
+++ b/calc.asm
@@ -4,7 +4,8 @@ section .data
         operation_text db "What operation would you like (+ OR -): "
 
 section .bss
-        input resb 16
+        first_num_input resb 16
+        second_num_input resb 16
 
 section .text
         .global _start
@@ -13,17 +14,12 @@ section .text
 _start:
         
         call _first_num_prompt
-
-        call _second_num_prompt
         
         call _get_first_num
 
-        // sys write
-        mov rax, 1
-        mov rdi, 1
-        lea rsi, [second_num_text]
-        mov rdx, 27
-        syscall
+        call _second_num_prompt
+        
+        call _get_second_num
         
         // sys read
         mov rax, 0
@@ -38,7 +34,15 @@ _start:
 _get_first_num:
         mov rax, 0
         mov rdi, 0
-        mov rsi, input
+        mov rsi, first_num_input
+        mov rdx, 16
+        syscall
+        ret
+
+_get_second_num:
+        mov rax, 0
+        mov rdi, 0
+        mov rsi, second_num_input
         mov rdx, 16
         syscall
         ret

--- a/calc.asm
+++ b/calc.asm
@@ -1,7 +1,7 @@
 section .data
-        first_num_prompt db "Enter the first integer: "
-        second_num_prompt db "Enter the second integer: "
-        operation_prompt db "What operation would you like (+ OR -): "
+        first_num_text db "Enter the first integer: "
+        second_num_text db "Enter the second integer: "
+        operation_text db "What operation would you like (+ OR -): "
 
 section .bss
         input resb 16
@@ -12,12 +12,7 @@ section .text
 
 _start:
         
-        // sys write
-        mov rax, 1
-        mov rdi, 1
-        lea rsi, [first_num_prompt]
-        mov rdx, 26
-        syscall
+        call _first_num_prompt
 
         // sys read
         mov rax, 0
@@ -31,7 +26,7 @@ _start:
         // sys write
         mov rax, 1
         mov rdi, 1
-        lea rsi, [second_num_prompt]
+        lea rsi, [second_num_text]
         mov rdx, 27
         syscall
         
@@ -59,3 +54,11 @@ _start:
         //lea rsi, [new_line]
         //mov rdx, 1
         //syscall
+
+_first_num_prompt:
+        mov rax, 1
+        mov rdi, 1
+        mov rsi, first_num_text
+        mov rdx, 25
+        syscall
+        ret

--- a/calc.asm
+++ b/calc.asm
@@ -20,16 +20,8 @@ _start:
         call _second_num_prompt
         
         call _get_second_num
-        
-        // sys read
-        mov rax, 0
-        sub rsp, 8
-        mov rdi, 0
-        lea rsi, [rsp]
-        // TODO: store users input from rsp
-        mov rdx, 1
-        syscall
 
+        call _operation_prompt
 
 _get_first_num:
         mov rax, 0
@@ -60,5 +52,13 @@ _second_num_prompt:
         mov rdi, 1
         mov rsi, second_num_text
         mov rdx, 26
+        syscall
+        ret
+
+_operation_prompt:
+        mov rax, 1
+        mov rdi, 1
+        mov rsi, operation_text
+        mov rdx, 40
         syscall
         ret

--- a/calc.asm
+++ b/calc.asm
@@ -14,6 +14,8 @@ _start:
         
         call _first_num_prompt
 
+        call _second_num_prompt
+        
         // sys read
         mov rax, 0
         sub rsp, 8
@@ -60,5 +62,13 @@ _first_num_prompt:
         mov rdi, 1
         mov rsi, first_num_text
         mov rdx, 25
+        syscall
+        ret
+
+_second_num_prompt:
+        mov rax, 1
+        mov rdi, 1
+        mov rsi, second_num_text
+        mov rdx, 26
         syscall
         ret

--- a/calc.asm
+++ b/calc.asm
@@ -34,21 +34,6 @@ _start:
         mov rdx, 1
         syscall
 
-        // write back input
-        mov rax, 1
-        mov rdi, 1
-        // users input is still in rsp
-        mov rdx, 2
-        syscall
-
-        
-
-        // sys write
-        //mov rax, 1
-        //mov rdi, 1
-        //lea rsi, [new_line]
-        //mov rdx, 1
-        //syscall
 
 _get_first_num:
         mov rax, 0


### PR DESCRIPTION
Switch to using NASM assembly syntax and `nasm` and `ld` to build executable instead of `gcc`. The only reason for doing this is that there seems to be more learning resources available for NASM than intel, making this project easier henceforward. Also, using `ld` instead of `gcc` so that the created binary is barebones without having to tell gcc `-nostdlib`. 